### PR TITLE
feat: Implementa fluxo completo de registro de usuário

### DIFF
--- a/src/main/java/br/com/maisprati/api/ApiApplication.java
+++ b/src/main/java/br/com/maisprati/api/ApiApplication.java
@@ -9,5 +9,4 @@ public class ApiApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(ApiApplication.class, args);
 	}
-
 }

--- a/src/main/java/br/com/maisprati/api/controller/AuthController.java
+++ b/src/main/java/br/com/maisprati/api/controller/AuthController.java
@@ -1,0 +1,28 @@
+package br.com.maisprati.api.controller;
+
+import br.com.maisprati.api.dto.RegisterDto;
+import br.com.maisprati.api.dto.UserResponseDto;
+import br.com.maisprati.api.model.User;
+import br.com.maisprati.api.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/register")
+    public ResponseEntity<UserResponseDto> register(@RequestBody RegisterDto dados) {
+        UserResponseDto usuarioCadastrado = authService.register(dados);
+        return ResponseEntity.status(201).body(usuarioCadastrado);
+    }
+}
+
+

--- a/src/main/java/br/com/maisprati/api/dto/RegisterDto.java
+++ b/src/main/java/br/com/maisprati/api/dto/RegisterDto.java
@@ -1,0 +1,11 @@
+package br.com.maisprati.api.dto;
+
+import lombok.Data;
+
+@Data
+public class RegisterDto {
+
+    private String nomeCompleto;
+    private String email;
+    private String senha;
+}

--- a/src/main/java/br/com/maisprati/api/dto/UserResponseDto.java
+++ b/src/main/java/br/com/maisprati/api/dto/UserResponseDto.java
@@ -1,0 +1,23 @@
+package br.com.maisprati.api.dto;
+
+import br.com.maisprati.api.model.User;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class UserResponseDto {
+    private Long id;
+    private String nomeCompleto;
+    private String email;
+    private String fotoPerfil;
+    private Integer streakAtual;
+
+    public UserResponseDto(User user) {
+        this.id = user.getId();
+        this.nomeCompleto = user.getNomeCompleto();
+        this.email = user.getEmail();
+        this.fotoPerfil = user.getFotoPerfil();
+        this.streakAtual = user.getStreakAtual();
+    }
+}

--- a/src/main/java/br/com/maisprati/api/repository/UserRepository.java
+++ b/src/main/java/br/com/maisprati/api/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package br.com.maisprati.api.repository;
+
+import br.com.maisprati.api.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    User findByEmail(String email);
+}

--- a/src/main/java/br/com/maisprati/api/security/SecurityConfig.java
+++ b/src/main/java/br/com/maisprati/api/security/SecurityConfig.java
@@ -1,0 +1,15 @@
+package br.com.maisprati.api.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/br/com/maisprati/api/service/AuthService.java
+++ b/src/main/java/br/com/maisprati/api/service/AuthService.java
@@ -1,0 +1,46 @@
+package br.com.maisprati.api.service;
+
+import br.com.maisprati.api.dto.RegisterDto;
+import br.com.maisprati.api.dto.UserResponseDto;
+import br.com.maisprati.api.model.User;
+import br.com.maisprati.api.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor // Cria um construtor com todos os campos `final`
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * Registra um novo usuário no sistema.
+     * Realiza a validação de e-mail duplicado e criptografa a senha antes de salvar.
+     *
+     * @param dados DTO contendo nome, e-mail e senha do novo usuário.
+     * @return um DTO com os dados do usuário recém-criado, sem a senha.
+     * @throws RuntimeException se o e-mail já estiver em uso.
+     */
+    public UserResponseDto register(RegisterDto dados) {
+        if (userRepository.findByEmail(dados.getEmail()) != null) {
+            throw new RuntimeException("E-mail já cadastrado!");
+        }
+
+        String senhaCriptografada = passwordEncoder.encode(dados.getSenha());
+
+        User novoUsuario = new User(
+                null, // id é null porque o DB vai gerá-lo automaticamente
+                dados.getNomeCompleto(),
+                dados.getEmail(),
+                senhaCriptografada,
+                null,
+                0
+        );
+
+        User usuarioSalvo = userRepository.save(novoUsuario);
+
+        return new UserResponseDto(usuarioSalvo);
+    }
+}


### PR DESCRIPTION
Esta funcionalidade introduz a capacidade de um novo usuário se registrar na plataforma através do endpoint POST /api/auth/register.

- Criação da camada de Serviço (`AuthService`) para conter a lógica de negócio.
- Implementação da validação para evitar e-mails duplicados.
- Adição do `PasswordEncoder` (BCrypt) para garantir o armazenamento seguro de senhas.
- Criação de DTOs para entrada (`RegisterDto`) e saída (`UserResponseDto`), garantindo que a senha nunca seja exposta na API.
- Configuração do `UserRepository` com um método customizado (`findByEmail`).
- O endpoint retorna o status HTTP 201 Created e os dados do usuário em caso de sucesso.

Closes #2